### PR TITLE
Add demo videos and blogs for students

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,144 +1,117 @@
-# JavaScript Project Instructions
+# Planning, Tips, and Support
 
-<!-- toc -->
+Unlike labs, projects do not have the guardrails of a README and tests to structure your work. Instead, you need to design and plan your features yourself. These tips should help you plan your project effectively.
 
-- [Overview](#overview)
-- [Objectives](#objectives)
-- [Project Deliverables](#project-deliverables)
-- [Technical and Complexity Requirements](#technical-and-complexity-requirements)
-- [What to Expect in Your Project Review](#what-to-expect-in-your-project-review)
-- [Example Projects](#example-projects)
+## Project Support
 
-<!-- tocstop -->
+As you complete the labs leading up to the project, you should receive an email from the Section Coach about scheduling a Project Planning Meeting. 
 
-## <a id="overview"></a>Overview
+In your Project Planning Meeting, you and your coach will discuss topics like
+- The basic story of your application
+- The core features you are planning to build
+- Your data models and their relationships
+- Challenges you expect to face
 
-Welcome to your JavaScript Project!
+If you do not receive an email, and have checked your spam folder, please reach out to the Section Coach by slack or email. If reaching out by slack, please include your email address in your message.
 
-You are going build a Single Page Application (**SPA**). Your frontend will be built with HTML, CSS, and JavaScript. Your frontend will communicate with a backend API that you'll build with Ruby and Rails. This is a really exciting moment - the whole course up until this point is coming together!
+After the Project Planning Meeting, there are a few ways for you to find support with your project as you build:
 
-## <a id="objectives"></a>Objectives
+- Attend weekly Study Groups and Project Office Hours listed on the Study Groups tab in your learn.co account. See upcoming study groups at [Learn.co Study Groups](https://learn.co/study-groups). Office Hours and topic-specific Study Groups are the best place to leverage technical support from your instructors and fellow students!
+- Participate in the slack channel to discuss project concepts and questions.
+- Lastly, if you have questions about the project or the assessment that cannot be addressed using the above options, please do not use the Ask A Question feature. Instead, please reach out to your Section Coach and/or Section Lead. You can find your Section Lead using the following link: [Who are the section leads](http://help.learn.co/instructional-support/receiving-course-support/who-are-the-section-leads).
 
-Your goals with this project:
+Reminder: your work should be your own! For more details about the rules of the road, see [Project Rules of the Road](/project-rules-of-the-road.md).
 
-- Design and architect features across frontend and backend
-- Integrate JavaScript and Rails
-- Debug issues in small- to medium-sized projects
-- Build and iterate on a project MVP
-- Communicate in a technical environment
+## Communicating About Your Project
 
-## <a id="project-deliverables"></a>Project Deliverables
+Your project should shine. To help your vision come across clearly, you should create and submit the following along with your project:
 
-In order to schedule your Project Review, you must submit:
+- A `README.md` file with a description of the application
+- A _Blog Post_ telling the story behind the application, challenges you overcame, and what you learned
+- A 1-2 minute _Video Demo_ walking through the features of your application
 
-- A link to your project repo, with code for your Rails backend and HTML / CSS / JavaScript frontend.
-- A `README.md` file describing your application
-- A **Blog Post** about your application
-- A 2-4 minute **Video Demo** introducing your application
+The audience should be the technically-minded outsider that stumbles on your project. Do not expect that they will have any of the context behind your project - you need to tell them that context. Focus on telling them the story of your application. What problem does it solve? How do the features come together to solve that problem? Why did you decide to build it?
 
-Read below for more details about the technical requirements for your project. See the section "Communicating About Your Project" in the [Project Planning and Tips](project-planning-tips.md) document for more guidance on communicating about your project.
+### <a id="example-projects"></a>Example Videos & Blogs
 
-As always, your project must be your own work. For more details about the rules of the road, see [Project Rules of the Road](/project-rules-of-the-road.md).
+- *Wine and Dine* | [Video](https://drive.google.com/file/d/1C_Tsh-oi7BWLfGE6izajtJ0MnVYBRu0S/view) | [Blog](https://jenniferbusca.github.io/javascript_rails_api_project_oo_javascript)
+- *Trading App* | [Video](https://www.youtube.com/watch?v=IR5Dp7zgspQ&t=14s) | [Blog](https://bo1623.github.io/rails_and_javascript_project_-_trading_app)
 
-## <a id="technical-and-complexity-requirements"></a>Technical and Complexity Requirements
 
-In order to demonstrate your proficiency with what you've learned about web development with JavaScript, here are the requirements for your project. You should view these guidelines as a minimum bar for the features you include in your application. It's your project, and you are encouraged to go above and beyond these requirements.
+## Guidelines for working solo
 
-1. The application must be an HTML, CSS, and JavaScript frontend with a Rails API backend. All interactions between the client and the server must be handled asynchronously (AJAX) and use JSON as the communication format.
+When working on a team, you get to have explicit conversations about the design of your application and the choices you make. Since you are working solo, you need to be extra clear - and **write down** - the decisions you make about your project. This will not only help you think more clearly about your design, it will also give context to instructors if you ask for help, and help you communicate about your project when you are done.
 
-2. The JavaScript application must use Object Oriented JavaScript (classes) to encapsulate related data and behavior.
+## Planning
 
-3. The domain model served by the Rails backend must include a resource with at least one has-many relationship. For example, if you were building an Instagram clone, you might display a list of photos with associated comments.
+- Brainstorm the problem that you want your application to solve. It's okay to take inspiration for the features you want to build from other sites or projects you've seen (it's not okay to use their code though).
+- Plan what features your app will have. You can write **User Stories** to help make it clear what you are planning to build.
+- Model your domain. You need to know what the nouns in your project are - the objects in the 'world' of your application. It can be helpful to draw the relationships between your models.
+- Plan how your features will work.
 
-4. The backend and frontend must collaborate to demonstrate Client-Server Communication. Your application should have at least 3 AJAX calls, covering at least 2 of Create, Read, Update, and Delete (CRUD). Your client-side JavaScript code must use `fetch` with the appropriate HTTP verb, and your Rails API should use RESTful conventions.
+## User Stories
 
-Within these constraints, there is a huge variety of applications that you might build. Take some time to brainstorm the application you'd like to build. Take a look at the [example projects](#example-projects) at the bottom of this page for inspiration. You should build something that you are excited to talk about. That means being excited about the features you build and the technology that you use.
+**User Stories** are a powerful tool for succinctly describing a set of functionality in terms of what it allows the user to do.
 
-If you aren't sure about whether the domain or features you are planning to build will meet the technical requirements, you should reach out to an instructor for guidance. [Read more about instructor guidance below](#instructor-guidance).
+Some examples of user stories:
 
-### Best Practices
+- A user is able to view travel locations, add new travel locations, edit travel locations and delete travel locations.
+- A user is able to review a travel location
+- A user is able to edit and delete a review for a travel location
 
-You are encouraged to follow development best practices while you are building your application.
+When you have written the user stories for your application, you can turn them into the technical requirements needed in order to turn those stories into working features.
 
-#### JavaScript
+## Domain Modeling
 
-- [ ] Use classes and functions to organize your code into reusable pieces.
-- [ ] Translate JSON responses into JavaScript model objects using ES6 class or constructor function syntax.
-- [ ] Use ES6 features when appropriate (e.g. arrow functions, `let` & `const`, rest and spread syntax).
+As you turn your user stories into more clear technical specifications for features, you can start by modeling the data that your application will store and show. Identify the nouns in your stories, their properties, and their relationships.
 
-#### Rails
+A description of the domain for the above stories might be:
 
-- [ ] Follow Rails MVC and RESTful conventions. That means, for example, that a request `GET /puppies` ought to be handled by the `PuppiesController`, fetch puppies from the database using a `Puppy` Active Record model, and return a list of puppies as JSON.
-- [ ] Well-named variables and methods
-- [ ] Short, single-purpose methods
+- A travel location has a name, a description, a location and an image URL
+- A review has a comment and a rating
+- A review belongs to one travel location (a travel location has many reviews)
+- A travel location has an average rating that is calculated by its aggregate review ratings
 
-#### Git
+Later on, you will be ready to create the database schema and application models corresponding to this domain.
 
-- [ ] Aim for a large number of small commits - commit frequently!
-- [ ] Add meaningful messages to your commits. When you look back at your commits with `git log`, the messages should describe each change.
-- [ ] Don't include changes in a commit that aren't related to the commit message
+## MVP ASAP
 
-### Suggested Project Structure
+(Minimum Viable Product, As Soon As Possible)
 
-You must submit a link to the repo with the code for your project. There is no requirement for how you decide to structure the code within that repo, but in the past, students have had success using a structure like:
+Building things is hard. It's very hard to predict what will be difficult in a project. Sometimes things that appear on the surface to be easy will end up taking hours of debugging.
 
-```txt
-javascript-project/
-  backend/
-    app/
-    (...other rails files and folders)
-  frontend/
-    index.html
-    style.css
-    index.js
-  README.md
-```
+With that in mind, it's important to build a Minimum Viable Product (MVP) as quickly as possible. Instead of getting stuck on advanced features, start with a basic working version of the application, then steadily add features piece by piece.
 
-For more about setting up your backend, you can reference the lesson on [Creating a Rails API from Scratch](https://github.com/learn-co-curriculum/js-rails-as-api-creating-a-rails-api-from-scratch).
+## Build vertically, not horizontally
 
-## <a id="what-to-expect-in-your-project-review"></a>What To Expect In Your Project Review
+It's easy to end up having to do lots of rework and fixing depending on how you order the things you build in your application, particularly if you build 'horizontally'.
 
-Review the [What to Expect in Project Reviews](/what-to-expect-in-project-reviews.md) document for general guidance on what to expect in the Project Review.
+You can visualize all the parts you of an app you need to build as a grid, with the features along the x axis (columns) and the different layers of the stack along the y axis.
 
-### What should you be prepared for in Project Review?
+|                    | View Location | Browse Locations | Edit Location | Add Review | Edit Review |
+| ------------------ | ------------- | ---------------- | ------------- | ---------- | ----------- |
+| Styling            |               |                  |               |            |             |
+| View Logic         |               |                  |               |            |             |
+| Data Fetching      |               |                  |               |            |             |
+| Controller actions |               |                  |               |            |             |
+| Seed Data          |               |                  |               |            |             |
+| Models             |               |                  |               |            |             |
+| Migrations         |               |                  |               |            |             |
 
-During your project review, be prepared to:
+A strong temptation is build your project row-by-row. It _feels_ easy to start by writing all the migrations for all your models, then all the models, etc.
 
-1. Explain your code from execution point to exit point. Use the best technical vocabulary you can.
-2. Live code. This could be refactoring, adding a new feature, or both.
-3. Answer questions about your knowledge of _JavaScript Fundamentals_.
+**Do not do this!**
 
-In particular, the JavaScript Fundamentals concepts your reviewer may ask about include:
+If you try to build all your migrations, then all your models, then all your controllers, then all your fetch calls, then all your view logic, you will have a bad time. Inevitably, your view logic will end up requiring changes to the underlying layers, and you will write code that doesn't get used.
 
-- variables
-- data structures
-- functions
-- hoisting
-- scope
-- context
-- `this`
-- closures
-- ES6 syntax
-- `let`, `const`
-- arrow functions
+Instead, build **vertically**, column-by-column. Write code for all the vertical layers involved in one feature before moving on to the next feature. That way, you'll minimize rewriting, and end up with working features without waste.
 
-### Learning Goals
+The project process should look like:
 
-These are the skills and knowledge that you should aim to demonstrate through the project review.
-
-- Explain how Rails routes a request to a controller and method based on the URL and HTTP verb
-- Use `render json:` to render serialized JSON
-- Select, Create, and Modify DOM nodes
-- Attach listeners to DOM nodes to respond to user interaction
-- Use `preventDefault` to control form submit behavior
-- Use `fetch` with 'GET', 'POST', 'PATCH' & 'DELETE' HTTP methods
-- Create a JavaScript object with ES6 class syntax
-- Instantiate JavaScript objects and call methods on them.
-
-## <a id="example-projects"></a>Example Projects
-
-- [Beat Machine](https://beat-machine.com/)
-- [Bounce Game](http://bounce-123.s3-website-us-east-1.amazonaws.com/)
-- [Words With Nerds™](https://wordswithnerds.herokuapp.com/)
-- [Remixer](https://remixer-v2.firebaseapp.com/)
-- [Keyboard Karaoke](https://keyboard-karaoke.herokuapp.com/)
+- Planning: Write down your ideas (use diagrams!)
+- Start by creating the frontend and backend directories
+- Build the **R** from CRUD for just one model, _vertically!_ That means one migration, one model, one controller action, one `fetch` call, and one DOM update. Add seed data and confirm that your code works by testing it visually.
+- Then, build the next CRUD action (maybe Create or Update), again building **vertically**.
+- Continue building features one by one, (_vertically!_)
+- Add feature by feature, not model by model or layer by layer.
+- Test each feature, add styles, and create seed data as you go (not all at once at the end)


### PR DESCRIPTION
I received permission from both students for these resources; they know they are being added to the readme for future students. 

I also would suggest making the edit from 2-4 minutes to 1-2 minutes. Career services says video demos are for future employers and no one wants to spend 4 minutes watching an app demo. I tell students 2 minutes max. Just a suggestion!